### PR TITLE
Writable instead of through stream for partials

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var Handlebars = require('handlebars');
 var Promise = require('bluebird');
 var _ = require('lodash');
 var Path = require('path');
+var writable = require('./lib/writable');
 
 /**
  * Duck-typing to allow different promise implementations to work.
@@ -26,10 +27,9 @@ function getNameFromPath(path) {
 
 function getPromiseFromPipe(pipe, fn) {
   var d = Promise.defer();
-  pipe.pipe(through.obj(function (file, enc, cb) {
+  pipe.pipe(writable.obj(function (file, enc, cb) {
     var str = file.contents.toString();
     fn(file, str);
-    this.push(file);
     cb();
   }, function () {
     //end

--- a/lib/writable.js
+++ b/lib/writable.js
@@ -1,0 +1,30 @@
+var WritableStream = require('readable-stream/writable');
+var _ = require('lodash');
+
+function writable(options, write, end) {
+  if (_.isFunction(options)) {
+    end = write;
+    write = options;
+    options = {};
+  }
+
+  var w = new WritableStream(options);
+
+  w._write = write;
+  if (end) {
+    w.end = end;
+  }
+
+  return w;
+}
+
+module.exports = writable;
+module.exports.obj = function obj(options, write, end) {
+  if (_.isFunction(options)) {
+    end = write;
+    write = options;
+    options = {};
+  }
+
+  return writable(_.defaults(options, { objectMode: true, highWaterMark: 16 }), write, end);
+};

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gulp-util": "^3.0.1",
     "handlebars": "^2.0.0",
     "lodash": "^2.4.1",
+    "readable-stream": "^1.0.33",
     "through2": "^0.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello,

As through stream used for partials never gets read, it blocks on 16 (highWaterMark from rvagg/through2 library) items. This means that plugin can't support more than 16 partials at the moment. I can assume there is the same limit for helpers, but I didn't check.

This pull request introduces simple writable stream based on isaacs/readable-stream, that is used instead.

The other option I considered is just adding 'data' event listener on original through stream. That works as well, but it felt a bit too dirty.

If you'd like anything changed, just shout.

Cheers,
Dali
