### PR TITLE
clean unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   "author": "Dane Stuckel",
   "license": "ISC",
   "dependencies": {
-    "bluebird": "^2.9.3",
-    "gulp-util": "^3.0.2",
-    "handlebars": "^2.0.0",
-    "lodash": "^3.0.0",
-    "readable-stream": "^1.1.13",
-    "through2": "^0.6.3"
+    "bluebird": "^2.9",
+    "gulp-util": "^3.0",
+    "handlebars": ">=2",
+    "lodash": ">=2",
+    "readable-stream": "^1.1",
+    "through2": "^0.6"
   },
   "devDependencies": {
     "blanket": "^1.1.6",

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ Reads data, partials and helpers from asynchronous sources like a databases, fil
 
 [![NPM version](https://badge.fury.io/js/gulp-static-handlebars.svg)](http://badge.fury.io/js/gulp-static-handlebars)
 
-##Example with any A+ compatible promises library:
+## Example with any A+ compatible promises library:
 
 ```JavaScript
 
@@ -35,7 +35,7 @@ gulp.src('./app/index.hbs')
       
 ```
 
-##Another example with vinyl pipes
+## Another example with vinyl pipes
 
 ```JavaScript
 
@@ -48,7 +48,7 @@ gulp.src('./app/index.hbs')
 
 ```
 
-##Install
+## Install
 
 ```Sh
 
@@ -56,12 +56,12 @@ npm install gulp-static-handlebars
 
 ```
 
-##Running Tests
+## Running Tests
 
 To run the basic tests, just run `mocha` normally.  
 
 This assumes you've already installed the local npm packages with `npm install`.
 
-##To Do:
+## To Do:
 
 * Support more handlebars options


### PR DESCRIPTION
Clean up the unit tests to divide them by partial, helper, and data.  Add a space between ## and titles in readme because npmjs doesn't know how to read them (even though Github does).