### PR TITLE
Possibility to set/get Handlebars instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var gutil = require('gulp-util');
 var through = require('through2');
-var Handlebars = require('handlebars');
+var Handlebars = null;
 var Promise = require('bluebird');
 var _ = require('lodash');
 var Path = require('path');
@@ -59,7 +59,7 @@ function getPromises(obj, fn) {
   } else if (isPromise(obj)) {
     obj.then(function (result) {
       getPromises(result, fn);
-    })
+    });
   }
   return [];
 }
@@ -68,6 +68,7 @@ module.exports = function (data, options) {
   var dataDependencies;
   options = options || {};
   var dependencies = [];
+  Handlebars = instance();
   //Go through a partials object
 
   if (data) {
@@ -126,4 +127,15 @@ module.exports = function (data, options) {
   });
 };
 
-module.exports.Handlebars = Handlebars;
+function instance(handlebarsInstance) {
+  if (arguments.length == 1) {
+    Handlebars = handlebarsInstance;
+  } else {
+    if (!Handlebars) {
+      Handlebars = require('handlebars');
+    }
+  }
+  return Handlebars;
+}
+
+module.exports.instance = instance;

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ function getPartials() {
 gulp.src('./app/index.hbs')
       .pipe(handlebars(getData(), {helpers: getHelpers(), partials: getPartials()}))
       .pipe(gulp.dest('./dist'));
-      
+
 ```
 
 ## Another example with vinyl pipes
@@ -48,6 +48,15 @@ gulp.src('./app/index.hbs')
 
 ```
 
+## Get/Set Handlebars Instance
+```JavaScript
+
+var MyHandlebars = handlebars.instance() // get Handlebars
+handlebars.instance(MyHandlebars) // use another Handlebars instance
+
+```
+
+
 ## Install
 
 ```Sh
@@ -58,7 +67,7 @@ npm install gulp-static-handlebars
 
 ## Running Tests
 
-To run the basic tests, just run `mocha` normally.  
+To run the basic tests, just run `mocha` normally.
 
 This assumes you've already installed the local npm packages with `npm install`.
 

--- a/test/test.js
+++ b/test/test.js
@@ -24,9 +24,9 @@ function deferES6Promise() {
  * Clear away all the helpers and partials that we may create in our tests.
  */
 function clearHandlebars() {
-  handlebars.Handlebars.unregisterPartial('test');
-  handlebars.Handlebars.unregisterHelper('helper-function-export');
-  handlebars.Handlebars.unregisterHelper('test');
+  handlebars.instance().unregisterPartial('test');
+  handlebars.instance().unregisterHelper('helper-function-export');
+  handlebars.instance().unregisterHelper('test');
 }
 
 /**
@@ -158,7 +158,7 @@ describe('Gulp Static Handlebars', function () {
         .pipe(handlebars({contents: "contents!!"}, {partials: {'test': deferred.promise}}))
         .pipe(gUtil.buffer(function (err, files) {
           expect(files).to.have.length(lengthTest);
-          done()
+          done();
         }));
       deferred.resolve(partial);
 
@@ -485,4 +485,15 @@ describe('Gulp Static Handlebars', function () {
         done();
       });
   });
+
+  it('can use another Handlebars instance', function (done) {
+    var Handlebars = {
+      'test' : 'Handlebars'
+    };
+    handlebars.instance(Handlebars);
+    expect(Handlebars).to.be.equal(handlebars.instance());
+    handlebars.instance(null); // use default
+    done();
+  });
+
 });


### PR DESCRIPTION
It's helpful if you want to require the `gulp-static-handlebars` later/conditionally and provide an existing Handlebars instance to it. Also a better control over the version of Handlebars used.