### PR TITLE
Producing multiple html files from one template

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,7 @@ module.exports = function (data, options) {
       var tpl = Handlebars.compile(file.contents.toString());
 
       if( pages == null ) {
+        data._file = file;
         file.contents = new Buffer(tpl(data));
         self.push(file);
       } else {

--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ module.exports = function (data, options) {
 
 
   return through.obj(function (file, enc, callback) {
+    data._file = file; // I use the underscore on case of naming conflict
     var self = this;
     Promise.all(dependencies).then(function () {
       file.contents = new Buffer(Handlebars.compile(file.contents.toString())(data));


### PR DESCRIPTION
I'm doing something kinda a static blog and I need to produce a several pages from one template.
I change a little your package and now I can do it the next way:
```
.pipe(handlebars(data, {
   pages: {
      'my-page.handlebars' : ['my-page.html', 'my-page-2.html', 'my-page-3.html']
   },
   helpers: gulp.src(config.src.helpers),
   partials: gulp.src(config.src.includes)
}))
```
In package I take this property:
```var pages = options.pages[ parsedPath.base ];```
And do a loop in which I generate html files from compiled template:
```
      var tpl = Handlebars.compile(file.contents.toString());

      if( pages == null ) {
        data._file = file;
        file.contents = new Buffer(tpl(data));
        self.push(file);
      } else {
        pages.forEach(function (pageName, i) {
          var pageFile = file.clone();
          parsedPath.base = pageName;
          pageFile.path = path.format(parsedPath);
          data._pageNum = i;
          data._file = pageFile;

          pageFile.contents = new Buffer(tpl(data));
          self.push(pageFile);
        });
      }
```