### PR TITLE
External template render function

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,7 @@ module.exports = function (data, options) {
       var tpl = Handlebars.compile(file.contents.toString());
 
       if( pages == null ) {
+        data._file = file;
         file.contents = new Buffer(tpl(data));
         self.push(file);
       } else {

--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ module.exports = function (data, options) {
 
 
   return through.obj(function (file, enc, callback) {
+    data._file = file; // I use the underscore on case of naming conflict
     var self = this;
     Promise.all(dependencies).then(function () {
       file.contents = new Buffer(Handlebars.compile(file.contents.toString())(data));


### PR DESCRIPTION
Hi! Because you didn't like my previous request https://github.com/TakenPilot/gulp-static-handlebars/pull/11 I I came up with new, more powerful and abstract feature.
Now, You just need to pass into options a render function. Then this function will be able to produce many files from one template.
See my render function example: https://bitbucket.org/dddenisss/static-gallery-demo/src/d9426de468d2de8658a9837f7a2e9e99e5b4e8cc/gulpfile.js/tasks/handlebars-compiler.js?at=default&fileviewer=file-view-default
Via this function you can produce html for a several languages or different content.
I think this will be really useful.
